### PR TITLE
Feature/align

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,4 +53,4 @@ jobs:
         run: dotnet pack -c Release --no-restore -o ${GITHUB_WORKSPACE}/packages -p:RepositoryBranch=$BRANCH_NAME /p:PublicRelease=true
 
       - name: 📦 Push packages to NuGet
-        run: dotnet nuget push ${GITHUB_WORKSPACE}/packages/'Atc.Test.'${NBGV_NuGetPackageVersion}'.nupkg' -k ${{ secrets.NUGET_KEY }} -s ${{ env.NUGET_REPO_URL }} --skip-duplicate
+        run: dotnet nuget push ${GITHUB_WORKSPACE}/packages/'Atc.Test.'${NBGV_NuGetPackageVersion}'.nupkg' -k ${{ secrets.NUGET_KEY }} -s ${{ env.NUGET_REPO_URL }} --skip-duplicate --no-symbols true

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -41,7 +41,7 @@
   <ItemGroup Label="Code Analyzers">
     <PackageReference Include="AsyncFixer" Version="1.5.1" PrivateAssets="All" />
     <PackageReference Include="Asyncify" Version="0.9.7" PrivateAssets="all" />
-    <PackageReference Include="Meziantou.Analyzer" Version="1.0.645" PrivateAssets="all" />
+    <PackageReference Include="Meziantou.Analyzer" Version="1.0.646" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.3" PrivateAssets="All" />
     <PackageReference Include="SecurityCodeScan" Version="3.5.3" PrivateAssets="all" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="All" />

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+      "rollForward": "latestMajor",
+      "allowPrerelease": false
+  }
+}

--- a/src/Atc.Test/Atc.Test.csproj
+++ b/src/Atc.Test/Atc.Test.csproj
@@ -6,6 +6,12 @@
     <Description>Common tools for writing tests using XUnit, AutoFixture, NSubstitute and FluentAssertions.</Description>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <!-- Ensure projects in src folder are not labeled as test project (regardless of project name) -->
+    <IsTestProject>false</IsTestProject>
+    <SonarQubeTestProject>false</SonarQubeTestProject>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="AutoFixture.AutoNSubstitute" Version="4.15.0" />
     <PackageReference Include="AutoFixture.Xunit2" Version="4.15.0" />

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -52,10 +52,6 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <!-- Web projects aren't packable by default. To override the default behavior, add the following -->
     <!--<IsPackable>true</IsPackable>-->
-
-    <!-- Ensure projects in src folder are not labeled as test project (regardless of project name) -->
-    <IsTestProject>false</IsTestProject>
-    <SonarQubeTestProject>false</SonarQubeTestProject>
   </PropertyGroup>
 
   <!--

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -6,17 +6,6 @@
   -->
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory).., Directory.Build.props))\Directory.Build.props" />
 
-  <!--
-  Place this in your csproj file for each package that needs to be generated.
-
-  <PropertyGroup>
-    <PackageId>my-id</PackageId>
-    <PackageTags>tag1;tag2</PackageTags>
-    <Description>Package description.</Description>
-  </PropertyGroup>
-
-  -->
-
   <!-- Global nuget package configurations that should not be needed to change -->
   <PropertyGroup Label="Global Nuget Package metadata">
     <RepositoryUrl>https://github.com/$(OrganizationName)/$(RepositoryName)</RepositoryUrl>
@@ -28,30 +17,27 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- Ensures package icon is valid -->
     <None Include="..\..\images\icon.png" Pack="true" PackagePath="\" Visible="false" />
   </ItemGroup>
 
   <PropertyGroup Label="Build instructions">
     <OutputType>Library</OutputType>
-    <TargetFramework>netstandard2.1</TargetFramework>
-
-    <!-- creates a regular package and a symbols package -->
+    <TargetFramework>net5.0</TargetFramework>
+    <!-- Creates a regular package and a symbols package -->
     <IncludeSymbols>true</IncludeSymbols>
     <!-- Creates symbol package in the new .snupkg format -->
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <!--
-      instruct the build system to embed project source files that are not tracked by the source control
+      Instruct the build system to embed project source files that are not tracked by the source control
       or imported from a source package to the generated PDB.
     -->
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <!-- Recommended: Embed symbols containing Source Link in the main file (exe/dll) -->
     <DebugType>embedded</DebugType>
-
     <!-- Will generate nuget packages for each project -->
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <!-- Web projects aren't packable by default. To override the default behavior, add the following -->
-    <!--<IsPackable>true</IsPackable>-->
+    <IsPackable>true</IsPackable>
   </PropertyGroup>
 
   <!--


### PR DESCRIPTION
This PR will align project with latest atc reference repo (atc-cosmos) and fixes issue #8.

Changes include: 
- Move project specific properties to project file
- Add `--no-symbols true` when pushing nuget package
- Add global.json
- Upgrade Meziantou.Analyzer package to 1.0.646
- Align src/Directory.Build.Props