### PR TITLE
Set target framework specifically in project

### DIFF
--- a/src/Atc.Test/Atc.Test.csproj
+++ b/src/Atc.Test/Atc.Test.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <PackageId>Atc.Test</PackageId>
     <PackageTags>xunit;NSubstitute;AutoFixture;FluentAssertions</PackageTags>
     <Description>Common tools for writing tests using XUnit, AutoFixture, NSubstitute and FluentAssertions.</Description>


### PR DESCRIPTION
Moved the TargetFramework property to the project file to avoid it being overwritten when aligning Directory.Build.props