### PR TITLE
Hotfix/type load exception

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -472,3 +472,4 @@ dotnet_diagnostic.S1135.severity = suggestion       # https://github.com/atc-net
 ##########################################
 dotnet_diagnostic.CA1062.severity = none            # Do not demand null-checking when using nullable reference types.
 dotnet_diagnostic.CA1014.severity = none            # No need for CLSCompliantAttribute
+dotnet_diagnostic.SA1011.severity = none            # Space needed after closing square bracet "]" needed for nullable arrays

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -43,9 +43,9 @@
     <PackageReference Include="Asyncify" Version="0.9.7" PrivateAssets="all" />
     <PackageReference Include="Meziantou.Analyzer" Version="1.0.646" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.3" PrivateAssets="All" />
-    <PackageReference Include="SecurityCodeScan" Version="3.5.3" PrivateAssets="all" />
+    <PackageReference Include="SecurityCodeScan.VS2019" Version="5.0.0" PrivateAssets="all" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="All" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.17.0.26580" PrivateAssets="all" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.18.0.27296" PrivateAssets="all" />
   </ItemGroup>
 
 </Project>

--- a/src/Atc.Test/Customizations/AutoRegisterCustomization.cs
+++ b/src/Atc.Test/Customizations/AutoRegisterCustomization.cs
@@ -12,6 +12,8 @@ namespace Atc.Test.Customizations
     /// </summary>
     public class AutoRegisterCustomization : ICustomization
     {
+        private static Type[]? autoRegisterTypes;
+
         /// <inheritdoc/>
         public void Customize(IFixture fixture)
         {
@@ -20,11 +22,14 @@ namespace Atc.Test.Customizations
                 throw new ArgumentNullException(nameof(fixture));
             }
 
-            var autoRegisterTypes = AppDomain.CurrentDomain
-                .GetAssemblies()
-                .SelectMany(GetLoadableTypes)
-                .Where(HasAutoRegisterAttribute)
-                .ToArray();
+            if (autoRegisterTypes is null)
+            {
+                autoRegisterTypes = AppDomain.CurrentDomain
+                    .GetAssemblies()
+                    .SelectMany(GetLoadableTypes)
+                    .Where(HasAutoRegisterAttribute)
+                    .ToArray();
+            }
 
             foreach (var type in autoRegisterTypes)
             {

--- a/src/Atc.Test/Customizations/AutoRegisterCustomization.cs
+++ b/src/Atc.Test/Customizations/AutoRegisterCustomization.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using AutoFixture;
 using AutoFixture.Kernel;
 
@@ -20,7 +22,7 @@ namespace Atc.Test.Customizations
 
             var autoRegisterTypes = AppDomain.CurrentDomain
                 .GetAssemblies()
-                .SelectMany(a => a.GetTypes())
+                .SelectMany(GetLoadableTypes)
                 .Where(HasAutoRegisterAttribute)
                 .ToArray();
 
@@ -50,5 +52,18 @@ namespace Atc.Test.Customizations
             => type.GetCustomAttributes(
                 typeof(AutoRegisterAttribute),
                 inherit: false).Length > 0;
+
+        private static IEnumerable<Type> GetLoadableTypes(Assembly assembly)
+        {
+            try
+            {
+                return assembly.GetTypes();
+            }
+            catch (ReflectionTypeLoadException e)
+            {
+                return e.Types?.OfType<Type>()
+                    ?? Enumerable.Empty<Type>();
+            }
+        }
     }
 }


### PR DESCRIPTION
This PR fixes a bug that throws `ReflectionTypeLoadException` when running multiple tests in parallel.

Changes include:
- Update analyzers
- Fix issue with unloadable types
- Optimize for performance by caching customization types