### PR TITLE
Feature/fix attributes

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -39,13 +39,10 @@
 
   <!-- Shared code analyzers used for all projects in the solution -->
   <ItemGroup Label="Code Analyzers">
-    <PackageReference Include="AsyncFixer" Version="1.5.1" PrivateAssets="All" />
-    <PackageReference Include="Asyncify" Version="0.9.7" PrivateAssets="all" />
-    <PackageReference Include="Meziantou.Analyzer" Version="1.0.661" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.3" PrivateAssets="All" />
-    <PackageReference Include="SecurityCodeScan.VS2019" Version="5.1.0" PrivateAssets="all" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="All" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.22.0.31243" PrivateAssets="all" />
+    <PackageReference Include="SecurityCodeScan.VS2019" Version="5.2.1" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.321" PrivateAssets="All" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.29.0.36737" />
   </ItemGroup>
 
 </Project>

--- a/src/Atc.Test/Atc.Test.csproj
+++ b/src/Atc.Test/Atc.Test.csproj
@@ -16,7 +16,7 @@
   <ItemGroup>
     <PackageReference Include="AutoFixture.AutoNSubstitute" Version="4.17.0" />
     <PackageReference Include="AutoFixture.Xunit2" Version="4.17.0" />
-    <PackageReference Include="FluentAssertions" Version="5.10.3" />
+    <PackageReference Include="FluentAssertions" Version="6.1.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="NSubstitute" Version="4.2.2" />
     <PackageReference Include="xunit.extensibility.core" Version="2.4.1" />

--- a/src/Atc.Test/EquivalencyAssertionOptionsExtensions.cs
+++ b/src/Atc.Test/EquivalencyAssertionOptionsExtensions.cs
@@ -24,6 +24,28 @@ namespace Atc.Test
             => (options ?? throw new ArgumentNullException(nameof(options)))
                 .Using<DateTimeOffset>(ctx => ctx.Subject
                     .Should()
+                    .BeCloseTo(ctx.Expectation, TimeSpan.FromMilliseconds(precision)))
+                .WhenTypeIs<DateTimeOffset>()
+                .Using<DateTime>(ctx => ctx.Subject
+                    .Should()
+                    .BeCloseTo(ctx.Expectation, TimeSpan.FromMilliseconds(precision)))
+                    .WhenTypeIs<DateTime>();
+
+        /// <summary>
+        /// Configures .BeEquivalentTo extensions to compare <see cref="DateTime"/> and
+        /// <see cref="DateTimeOffset "/> values by checking if they are within the specified
+        /// number of milliseconds (default = 1s).
+        /// </summary>
+        /// <typeparam name="T">The generic parameter for the <see cref="EquivalencyAssertionOptions{T}"/>.</typeparam>
+        /// <param name="options">The <see cref="EquivalencyAssertionOptions{T}"/> to configure.</param>
+        /// <param name="precision">The precision.</param>
+        /// <returns>The configured <see cref="EquivalencyAssertionOptions{T}"/>.</returns>
+        public static EquivalencyAssertionOptions<T> CompareDateTimeUsingCloseTo<T>(
+            this EquivalencyAssertionOptions<T> options,
+            TimeSpan precision)
+            => (options ?? throw new ArgumentNullException(nameof(options)))
+                .Using<DateTimeOffset>(ctx => ctx.Subject
+                    .Should()
                     .BeCloseTo(ctx.Expectation, precision))
                 .WhenTypeIs<DateTimeOffset>()
                 .Using<DateTime>(ctx => ctx.Subject

--- a/src/Atc.Test/InlineAutoNSubstituteDataAttribute.cs
+++ b/src/Atc.Test/InlineAutoNSubstituteDataAttribute.cs
@@ -13,9 +13,9 @@ namespace Atc.Test
     /// NSubstitute is used when the type is abstract, or when the <see cref="SubstituteAttribute"/> is applied.
     /// </remarks>
     [SuppressMessage(
-            "Design",
-            "CA1019:Define accessors for attribute arguments",
-            Justification = "By design")]
+        "Design",
+        "CA1019:Define accessors for attribute arguments",
+        Justification = "By design")]
     public sealed class InlineAutoNSubstituteDataAttribute : CompositeDataAttribute
     {
         /// <summary>

--- a/test/.editorconfig
+++ b/test/.editorconfig
@@ -54,3 +54,5 @@ dotnet_diagnostic.CA1062.severity = none            # Null checking input to tes
 dotnet_diagnostic.CA1812.severity = none            # Test classes used as generic arguments but not instantiated should be allowed.
 dotnet_diagnostic.SA1202.severity = none            # Private helper methods makes sense to keep at top of test classes, as tests are added to bottom.
 dotnet_diagnostic.CA2201.severity = none            # Instantiating Exceptions as test data should be allowed.
+dotnet_diagnostic.CA1711.severity = none            # Identifiers should not have incorrect suffix
+dotnet_diagnostic.S2344.severity = none             # Enumeration type names should not have "Flags" or "Enum" suffixes

--- a/test/Atc.Test.Tests/Atc.Test.Tests.csproj
+++ b/test/Atc.Test.Tests/Atc.Test.Tests.csproj
@@ -8,13 +8,13 @@
 
   <ItemGroup>
 
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.0.3">
+    <PackageReference Include="coverlet.collector" Version="3.1.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/test/Atc.Test.Tests/AutoNSubStituteDataAttributeTests.cs
+++ b/test/Atc.Test.Tests/AutoNSubStituteDataAttributeTests.cs
@@ -7,23 +7,9 @@ namespace Atc.Test.Tests
 {
     public class AutoNSubStituteDataAttributeTests
     {
-        public interface IInterfaceType
-        {
-            public string? StringProperty { get; set; }
-
-            public int IntProperty { get; set; }
-        }
-
-        public class ConcreteType
-        {
-            public string? StringProperty { get; set; }
-
-            public int IntProperty { get; set; }
-        }
-
         [Theory, AutoNSubstituteData]
         public void Should_Create_Concrete_Type_With_AutoFixture(
-            ConcreteType concreteType)
+            SampleClass concreteType)
         {
             concreteType
                 .Should().NotBeNull();
@@ -39,7 +25,7 @@ namespace Atc.Test.Tests
 
         [Theory, AutoNSubstituteData]
         public void Should_Create_Abstract_Type_With_NSubstitute(
-            IInterfaceType abstractType,
+            ISampleInterface abstractType,
             string str,
             int i)
         {

--- a/test/Atc.Test.Tests/InlineAutoNSubstituteDataAttributeTests.cs
+++ b/test/Atc.Test.Tests/InlineAutoNSubstituteDataAttributeTests.cs
@@ -1,0 +1,28 @@
+using AutoFixture.Xunit2;
+using FluentAssertions;
+using Xunit;
+
+namespace Atc.Test.Tests
+{
+    public class InlineAutoNSubstituteDataAttributeTests
+    {
+        [Theory]
+        [InlineAutoNSubstituteData(SampleEnum.One)]
+        [InlineAutoNSubstituteData(SampleEnum.Two)]
+        [InlineAutoNSubstituteData(SampleEnum.Three)]
+        public void InlineAutoNSubstituteData_Should_Call_For_Each_Value(
+            SampleEnum value,
+            [Frozen] ISampleInterface interfaceType,
+            SampleClass concreteType,
+            SampleDependantClass dependantType)
+        {
+            value.Should().BeOneOf(SampleEnum.One, SampleEnum.Two, SampleEnum.Three);
+            interfaceType.Should().NotBeNull();
+            interfaceType.IsSubstitute().Should().BeTrue();
+            concreteType.Should().NotBeNull();
+            concreteType.IsSubstitute().Should().BeFalse();
+            dependantType.Should().NotBeNull();
+            dependantType.Dependency.Should().Be(interfaceType);
+        }
+    }
+}

--- a/test/Atc.Test.Tests/MemberAutoNSubstituteDataAttributeTests.cs
+++ b/test/Atc.Test.Tests/MemberAutoNSubstituteDataAttributeTests.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using AutoFixture.Xunit2;
+using FluentAssertions;
+using Xunit;
+
+namespace Atc.Test.Tests
+{
+    public class MemberAutoNSubstituteDataAttributeTests
+    {
+        public static readonly IEnumerable<object[]> TestData = new object[][]
+        {
+            new object[] { SampleEnum.One },
+            new object[] { SampleEnum.Two },
+            new object[] { SampleEnum.Three },
+        };
+
+        [Theory]
+        [MemberAutoNSubstituteData(nameof(TestData))]
+        public void MemberAutoNSubstituteData_Should_Call_For_Each_Value(
+            SampleEnum value,
+            [Frozen] ISampleInterface interfaceType,
+            SampleClass concreteType,
+            SampleDependantClass dependantType)
+        {
+            value.Should().BeOneOf(SampleEnum.One, SampleEnum.Two, SampleEnum.Three);
+            interfaceType.Should().NotBeNull();
+            interfaceType.IsSubstitute().Should().BeTrue();
+            concreteType.Should().NotBeNull();
+            concreteType.IsSubstitute().Should().BeFalse();
+            dependantType.Should().NotBeNull();
+            dependantType.Dependency.Should().Be(interfaceType);
+        }
+    }
+}

--- a/test/Atc.Test.Tests/SampleTypes/ISampleInterface.cs
+++ b/test/Atc.Test.Tests/SampleTypes/ISampleInterface.cs
@@ -1,0 +1,9 @@
+﻿namespace Atc.Test.Tests
+{
+    public interface ISampleInterface
+    {
+        public string? StringProperty { get; set; }
+
+        public int IntProperty { get; set; }
+    }
+}

--- a/test/Atc.Test.Tests/SampleTypes/SampleClass.cs
+++ b/test/Atc.Test.Tests/SampleTypes/SampleClass.cs
@@ -1,0 +1,9 @@
+﻿namespace Atc.Test.Tests
+{
+    public class SampleClass
+    {
+        public string? StringProperty { get; set; }
+
+        public int IntProperty { get; set; }
+    }
+}

--- a/test/Atc.Test.Tests/SampleTypes/SampleDependantClass.cs
+++ b/test/Atc.Test.Tests/SampleTypes/SampleDependantClass.cs
@@ -1,0 +1,12 @@
+namespace Atc.Test.Tests
+{
+    public class SampleDependantClass
+    {
+        public SampleDependantClass(ISampleInterface dependency)
+        {
+            Dependency = dependency;
+        }
+
+        public ISampleInterface Dependency { get; }
+    }
+}

--- a/test/Atc.Test.Tests/SampleTypes/SampleEnum.cs
+++ b/test/Atc.Test.Tests/SampleTypes/SampleEnum.cs
@@ -1,0 +1,9 @@
+﻿namespace Atc.Test.Tests
+{
+    public enum SampleEnum
+    {
+        One,
+        Two,
+        Three,
+    }
+}


### PR DESCRIPTION
This PR fixes an issue with the MemberAutoNSubstituteDataAttribute where the test method is only called for the first set of data.