### PR TITLE
MemberAutoNSubstituteDataAttribute removes parameters with same values

### DIFF
--- a/src/Atc.Test/MemberAutoNSubstituteDataAttribute.cs
+++ b/src/Atc.Test/MemberAutoNSubstituteDataAttribute.cs
@@ -33,7 +33,7 @@ public sealed class MemberAutoNSubstituteDataAttribute : MemberDataAttributeBase
         var fixture = FixtureFactory.Create();
 
         return values
-            .Union(testMethod
+            .Concat(testMethod
                 .GetParameters()
                 .Skip(values.Length)
                 .Select(p => GetSpecimen(fixture, p)))

--- a/test/Atc.Test.Tests/MemberAutoNSubstituteDataAttributeTests.cs
+++ b/test/Atc.Test.Tests/MemberAutoNSubstituteDataAttributeTests.cs
@@ -2,7 +2,7 @@ namespace Atc.Test.Tests;
 
 public class MemberAutoNSubstituteDataAttributeTests
 {
-    public static readonly IEnumerable<object[]> TestData = new[]
+    public static readonly IEnumerable<object[]> MemberData = new[]
     {
         new object[] { SampleEnum.One },
         new object[] { SampleEnum.Two },
@@ -10,8 +10,8 @@ public class MemberAutoNSubstituteDataAttributeTests
     };
 
     [Theory]
-    [MemberAutoNSubstituteData(nameof(TestData))]
-    public void MemberAutoNSubstituteData_Should_Call_For_Each_Value(
+    [MemberAutoNSubstituteData(nameof(MemberData))]
+    public void MemberAutoNSubstituteData_Should_Call_For_MemberData(
         SampleEnum value,
         [Frozen] ISampleInterface interfaceType,
         SampleClass concreteType,
@@ -26,23 +26,23 @@ public class MemberAutoNSubstituteDataAttributeTests
         dependantType.Dependency.Should().Be(interfaceType);
     }
 
-    public static readonly IEnumerable<object[]> TestDataMultiple = new[]
+    public static readonly IEnumerable<object[]> MemberDataMultipleValues = new[]
     {
         new object[] { SampleEnum.One, SampleEnum.Two },
         new object[] { SampleEnum.One, SampleEnum.One },
     };
 
     [Theory]
-    [MemberAutoNSubstituteData(nameof(TestDataMultiple))]
-    public void MemberAutoNSubstituteData_Should_Call_For_Each_Value_Mutliple(
-        SampleEnum value1,
-        SampleEnum value2,
+    [MemberAutoNSubstituteData(nameof(MemberDataMultipleValues))]
+    public void MemberAutoNSubstituteData_Should_Call_For_Each_MemderData_Values(
+        SampleEnum firstValue,
+        SampleEnum secondValue,
         [Frozen] ISampleInterface interfaceType,
         SampleClass concreteType,
         SampleDependantClass dependantType)
     {
-        value1.Should().BeOneOf(SampleEnum.One, SampleEnum.Two, SampleEnum.Three);
-        value2.Should().BeOneOf(SampleEnum.One, SampleEnum.Two, SampleEnum.Three);
+        firstValue.Should().BeOneOf(SampleEnum.One, SampleEnum.Two, SampleEnum.Three);
+        secondValue.Should().BeOneOf(SampleEnum.One, SampleEnum.Two, SampleEnum.Three);
         interfaceType.Should().NotBeNull();
         interfaceType.IsSubstitute().Should().BeTrue();
         concreteType.Should().NotBeNull();

--- a/test/Atc.Test.Tests/MemberAutoNSubstituteDataAttributeTests.cs
+++ b/test/Atc.Test.Tests/MemberAutoNSubstituteDataAttributeTests.cs
@@ -25,4 +25,29 @@ public class MemberAutoNSubstituteDataAttributeTests
         dependantType.Should().NotBeNull();
         dependantType.Dependency.Should().Be(interfaceType);
     }
+
+    public static readonly IEnumerable<object[]> TestDataMultiple = new[]
+    {
+        new object[] { SampleEnum.One, SampleEnum.Two },
+        new object[] { SampleEnum.One, SampleEnum.One },
+    };
+
+    [Theory]
+    [MemberAutoNSubstituteData(nameof(TestDataMultiple))]
+    public void MemberAutoNSubstituteData_Should_Call_For_Each_Value_Mutliple(
+        SampleEnum value1,
+        SampleEnum value2,
+        [Frozen] ISampleInterface interfaceType,
+        SampleClass concreteType,
+        SampleDependantClass dependantType)
+    {
+        value1.Should().BeOneOf(SampleEnum.One, SampleEnum.Two, SampleEnum.Three);
+        value2.Should().BeOneOf(SampleEnum.One, SampleEnum.Two, SampleEnum.Three);
+        interfaceType.Should().NotBeNull();
+        interfaceType.IsSubstitute().Should().BeTrue();
+        concreteType.Should().NotBeNull();
+        concreteType.IsSubstitute().Should().BeFalse();
+        dependantType.Should().NotBeNull();
+        dependantType.Dependency.Should().Be(interfaceType);
+    }
 }


### PR DESCRIPTION
The current `MemberAutoNSubstituteDataAttribute` implementation uses `.Union` to merge parameters from a MemberData paramters and paramters generated by AutoFixtured and NSubstituted. However, `.Union` has the side effect of removing duplicate values. 

Replace `.Union` with `.Concat` instead.