### PR TITLE
fix(deps): update fluentassertions to 7.2.1 and allow new versions below 8.x

### DIFF
--- a/src/Atc.Test/Atc.Test.csproj
+++ b/src/Atc.Test/Atc.Test.csproj
@@ -16,7 +16,7 @@
   <ItemGroup>
     <PackageReference Include="AutoFixture.AutoNSubstitute" Version="4.18.1" />
     <PackageReference Include="AutoFixture.Xunit3" Version="4.19.0" />
-    <PackageReference Include="FluentAssertions" Version="[7.2.0]" /> <!-- FluentAssertions is version-pinned because versions newer than 7.1.0 require a paid license -->
+    <PackageReference Include="FluentAssertions" Version="[7.2.1,8.0)" /> <!-- FluentAssertions is version-pinned because major-versions after 7 require a paid license -->
     <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />


### PR DESCRIPTION
This PR updates NuGet package FluentAssertions from 7.2.0 to 7.2.1.

It will also allow projects to use newer versions of FluentAssertions in the future, as long as the major version is below 8.x.
This is accomplished by changing the version range from 
`Exact version match`
to 
`Mixed inclusive minimum and exclusive maximum version` 

This PR will fix the warning in my other project:
```
[NU1608] Warning As Error: Detected package version outside of dependency constraint: Atc.Test 2.0.16 requires FluentAssertions (= 7.2.0) but version FluentAssertions 7.2.1 was resolved.
```