### PR TITLE
Target net10.0 only and centralize the TFM

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -23,6 +23,7 @@
   </PropertyGroup>
 
   <PropertyGroup Label="Compile settings">
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <LangVersion>14.0</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/README.md
+++ b/README.md
@@ -58,7 +58,6 @@
 * Exact-type frozen promotion for member data (reuse supplied instance across later `[Frozen]` parameters).
 * Deterministic fixture configuration with opt‑in auto-registration of custom `ICustomization` / `ISpecimenBuilder` via `[AutoRegister]`.
 * Convenience extensions: equivalency options, substitute inspection helpers, task timeout helpers, object protected member access.
-* Multi-targeted (net8.0, net10.0) for broad compatibility.
 * Clear separation of concerns: you own the xUnit runner/version.
 
 ## Getting Started
@@ -258,7 +257,6 @@ public class GuidCustomization : ICustomization
 
 | Aspect | Value |
 |--------|-------|
-| Target Frameworks | net8.0, net10.0 |
 | Test Framework | xUnit v3 (must be referenced directly) |
 | Mocking | NSubstitute (transitively used for interfaces/abstract classes) |
 | Assertions | AwesomeAssertions (recommended) |

--- a/src/Atc.Test/Atc.Test.csproj
+++ b/src/Atc.Test/Atc.Test.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <PackageId>Atc.Test</PackageId>
     <PackageTags>xunit;NSubstitute;AutoFixture;AwesomeAssertions</PackageTags>
     <Description>Common tools for writing tests using XUnit, AutoFixture, NSubstitute and AwesomeAssertions.</Description>
@@ -21,7 +20,7 @@
   <ItemGroup>
     <PackageReference Include="AutoFixture.AutoNSubstitute" Version="4.18.1" />
     <PackageReference Include="AutoFixture.Xunit3" Version="4.19.0" />
-    <PackageReference Include="AwesomeAssertions" Version="[9.4.0,10.0)" /> <!-- AwesomeAssertions is the Apache-2.0 community fork of FluentAssertions 7.x; the upper bound keeps a transitive major (e.g. a future namespace rename) opt-in via our own major release -->
+    <PackageReference Include="AwesomeAssertions" Version="9.4.0" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="xunit.v3.extensibility.core" Version="3.2.2" />
   </ItemGroup>

--- a/test/Atc.Test.Tests/Atc.Test.Tests.csproj
+++ b/test/Atc.Test.Tests/Atc.Test.Tests.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
 
     <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>


### PR DESCRIPTION
# Summary

  - Drop net8.0; target net10.0 exclusively
  - Define the TFM once in the root Directory.Build.props
  - Remove now-redundant per-project TFM declarations

  # Changes

  ### :wrench: Configuration
  - Set <TargetFramework>net10.0</TargetFramework> in root props
  - Remove <TargetFrameworks> from Atc.Test.csproj
  - Remove redundant <TargetFramework> from the test project

  ### :fire: Removal
  - Drop net8.0 from the supported target frameworks

  ### :memo: Documentation
  - Remove the single-TFM references from the README

  # Breaking Changes

  - The package now targets net10.0 only.
  - Consumers on net8.0/net9.0 can no longer restore Atc.Test;
    they must move to net10.0.

  # Notes

  - TFM is now inherited solution-wide from Directory.Build.props,
    so new projects need no per-project target declaration.


BEGIN_COMMIT_OVERRIDE
feat!: drop netstandard2.1/net8.0/net9.0; target net10.0 exclusively
END_COMMIT_OVERRIDE